### PR TITLE
Make EntityFrameworkCore.Jet available on `net6.0`

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,6 +15,12 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatform">
+      <_Parameter1>windows</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
   <!-- TODO: Enable for 5.0
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" PrivateAssets="All" />

--- a/src/EFCore.Jet.Data/EFCore.Jet.Data.csproj
+++ b/src/EFCore.Jet.Data/EFCore.Jet.Data.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Description>Jet/ACE data provider for .NET used by EntityFramworkCore.Jet (Microsoft Access MDB/ACCDB files).</Description>
-        <TargetFramework>net6.0-windows</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Platforms>AnyCPU;x86;x64</Platforms>
         <AssemblyName>EntityFrameworkCore.Jet.Data</AssemblyName>
         <RootNamespace>EntityFrameworkCore.Jet.Data</RootNamespace>

--- a/src/EFCore.Jet.Odbc/EFCore.Jet.Odbc.csproj
+++ b/src/EFCore.Jet.Odbc/EFCore.Jet.Odbc.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Explicit ODBC support for Jet/ACE database provider for Entity Framework Core (Microsoft Access MDB/ACCDB files).</Description>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EntityFrameworkCore.Jet.Odbc</AssemblyName>
     <RootNamespace>EntityFrameworkCore.Jet</RootNamespace>
     <PackageTags>$(PackageTags);ODBC;System.Data.Odbc</PackageTags>

--- a/src/EFCore.Jet.OleDb/EFCore.Jet.OleDb.csproj
+++ b/src/EFCore.Jet.OleDb/EFCore.Jet.OleDb.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Explicit OLE DB support for Jet/ACE database provider for Entity Framework Core (Microsoft Access MDB/ACCDB files).</Description>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>EntityFrameworkCore.Jet.OleDb</AssemblyName>
     <RootNamespace>EntityFrameworkCore.Jet</RootNamespace>
     <PackageTags>$(PackageTags);OLE DB;OLEDB;System.Data.OleDb</PackageTags>

--- a/src/EFCore.Jet/EFCore.Jet.csproj
+++ b/src/EFCore.Jet/EFCore.Jet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Jet/ACE database provider for Entity Framework Core (Microsoft Access MDB/ACCDB files).</Description>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>EntityFrameworkCore.Jet</RootNamespace>
     <AssemblyName>EntityFrameworkCore.Jet</AssemblyName>
     <Platforms>AnyCPU;x86;x64</Platforms>


### PR DESCRIPTION
By using `[SupportedOSPlatform("windows")]` at assembly level instead of targeting `net6.0-windows`.

This will enable taking a dependency on the EntityFrameworkCore.Jet* NuGet packages on Linux and macOS. The consumer of EntityFrameworkCore.Jet can then decide how to handle [CA1416][1] either by adding `[SupportedOSPlatform("windows")]`, by targeting `net6.0-windows` or by testing `OperatingSystem.IsWindows()` at runtime.

[1]: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1416